### PR TITLE
replaced bn.js with bn-plus.js

### DIFF
--- a/packages/serializer/package.json
+++ b/packages/serializer/package.json
@@ -9,6 +9,7 @@
     "@swtc/common": "^1.0.11",
     "@swtc/keypairs": "^1.0.10",
     "@swtc/wallet": "^1.0.11",
+    "bn-plus.js": "^1.0.0",
     "bignumber.js": "^9.0.0",
     "extend": "^3.0.2",
     "jsbn": "^1.1.0",

--- a/packages/serializer/test/tumAmount.spec.js
+++ b/packages/serializer/test/tumAmount.spec.js
@@ -2,7 +2,7 @@ const chai = require("chai")
 const expect = chai.expect
 const Amount = require("../cjs/TumAmount").Factory()
 const Factory = require("@swtc/wallet").Factory
-const BN = require("bn.js")
+const BN = require("bn-plus.js")
 const testData = {
   value: "1",
   currency: "CNY",

--- a/packages/serializer/tssrc/TumAmount.ts
+++ b/packages/serializer/tssrc/TumAmount.ts
@@ -3,7 +3,7 @@
 // - Numbers in hex are big-endian.
 
 import Bignumber from "bignumber.js"
-import BN from "bn.js"
+import BN from "bn-plus.js"
 import extend from "extend"
 import { Factory as WalletFactory } from "@swtc/wallet"
 import { AMOUNT_CONSTS } from "@swtc/common"

--- a/packages/serializer/tssrc/Utils.ts
+++ b/packages/serializer/tssrc/Utils.ts
@@ -1,4 +1,4 @@
-import BN from "bn.js"
+import BN from "bn-plus.js"
 import SerializedType from "./types/SerializedType"
 
 /*

--- a/packages/serializer/tssrc/types/STAmount.ts
+++ b/packages/serializer/tssrc/types/STAmount.ts
@@ -1,4 +1,4 @@
-import BN from "bn.js"
+import BN from "bn-plus.js"
 import { BigInteger } from "jsbn"
 import { convertHexToByteArray } from "../Utils"
 import SerializedType from "./SerializedType"

--- a/packages/serializer/tssrc/types/STCurrency.ts
+++ b/packages/serializer/tssrc/types/STCurrency.ts
@@ -1,4 +1,4 @@
-import BN from "bn.js"
+import BN from "bn-plus.js"
 import { convertHexToByteArray, convertHexToString } from "../Utils"
 import SerializedType from "./SerializedType"
 

--- a/packages/serializer/tssrc/types/STHash128.ts
+++ b/packages/serializer/tssrc/types/STHash128.ts
@@ -1,4 +1,4 @@
-import BN from "bn.js"
+import BN from "bn-plus.js"
 import { isString, serializeHex } from "../Utils"
 import SerializedType from "./SerializedType"
 

--- a/packages/serializer/tssrc/types/STInt64.ts
+++ b/packages/serializer/tssrc/types/STInt64.ts
@@ -1,5 +1,5 @@
 import assert from "assert"
-import BN from "bn.js"
+import BN from "bn-plus.js"
 import { BigInteger } from "jsbn"
 import { isHexInt64String, isNumber, isString, serializeHex } from "../Utils"
 import SerializedType from "./SerializedType"


### PR DESCRIPTION
签名部分建议恢复用bn-plus.js，理由如下：

已cny转账为例，当转账数量为0.099时，bn.js底层抛出异常`Number can only safely store up to 53 bits (Amount)`, 正常情况下签名应该是成功的，用原来的bn-plus.js就没有这种问题，所以不建议轻易地用bn.js替换