### PR TITLE
add get multi signer and add signer function

### DIFF
--- a/packages/transaction/tssrc/transaction.ts
+++ b/packages/transaction/tssrc/transaction.ts
@@ -1270,13 +1270,6 @@ function Factory(Wallet = WalletFactory("jingtum")) {
      * }
      */
     public multiSigning(options: IMultiSigningOptions) {
-      // this.swt_normalize()
-      this.tx_json.SigningPubKey = "" // 多签中该字段必须有且必须为空字符串
-      if (!this.tx_json.Sequence) {
-        this.tx_json.Sequence = new Error("please set sequence first")
-        return this
-      }
-      // const tx_json_verify = JSON.parse(JSON.stringify(this.tx_json))
       const signers = this.tx_json.Signers || []
       if (signers.length > 0) {
         // 验签
@@ -1284,6 +1277,23 @@ function Factory(Wallet = WalletFactory("jingtum")) {
           this.tx_json.verifyTx = new Error("verify failed")
           return this
         }
+      }
+
+      const signer = this.getMultiSign(options)
+
+      this.tx_json.Signers = this.tx_json.Signers || []
+      this.tx_json.Signers.push({
+        Signer: signer
+      })
+      return this
+    }
+
+    // 只获取签名信息
+    public getMultiSign(options: IMultiSigningOptions) {
+      this.tx_json.SigningPubKey = "" // 多签中该字段必须有且必须为空字符串
+      if (!this.tx_json.Sequence) {
+        this.tx_json.Sequence = new Error("please set sequence first")
+        return this
       }
 
       const Account = options.account || options.address
@@ -1309,6 +1319,25 @@ function Factory(Wallet = WalletFactory("jingtum")) {
 
       signer.SigningPubKey = wt.getPublicKey()
       signer.TxnSignature = wt.signTx(hash)
+
+      return signer
+    }
+
+    public addMultiSign(signer: any) {
+      this.tx_json.SigningPubKey = "" // 多签中该字段必须有且必须为空字符串
+      if (!this.tx_json.Sequence) {
+        this.tx_json.Sequence = new Error("please set sequence first")
+        return this
+      }
+      // const tx_json_verify = JSON.parse(JSON.stringify(this.tx_json))
+      const signers = this.tx_json.Signers || []
+      if (signers.length > 0) {
+        // 验签
+        if (!verifyTx(this.tx_json)) {
+          this.tx_json.verifyTx = new Error("verify failed")
+          return this
+        }
+      }
 
       this.tx_json.Signers = this.tx_json.Signers || []
       this.tx_json.Signers.push({


### PR DESCRIPTION
多签的场景
1、参与者要获得自己的签名
2、发送签名给组织者
3、组织者发送合并的签名

现有接口必须要知道每个签名人的密钥，这个不合理

改进版本
1、每个人可以得到自己签名
2、组织者可以组装签名
如何传递签名，是参与者自己协商的过程。