### PR TITLE
use BN.isBN to compare bn instance

### DIFF
--- a/supporting/sm.js/lib/sm2.js
+++ b/supporting/sm.js/lib/sm2.js
@@ -102,12 +102,7 @@ function SM2KeyPair(pub, pri) {
       this._pubFromString(pub)
     } else if (Array.isArray(pub)) {
       this._pubFromBytes(pub)
-    } else if (
-      "x" in pub &&
-      pub.x instanceof BN &&
-      "y" in pub &&
-      pub.y instanceof BN
-    ) {
+    } else if ("x" in pub && BN.isBN(pub.x) && "y" in pub && BN.isBN(pub.y)) {
       // pub is already the Point object
       this.pub = pub
       validPub = true
@@ -118,7 +113,7 @@ function SM2KeyPair(pub, pri) {
   if (pri != null) {
     if (typeof pri === "string") {
       this.pri = new BN(pri, 16)
-    } else if (pri instanceof BN) {
+    } else if (BN.isBN(pri)) {
       this.pri = pri
       validPri = true
     } else {


### PR DESCRIPTION
If project install other version bn.js, init wallet instace of `guomi` that sm2.js throw `invalid private key` error.

This is [reproduce commit](https://github.com/GinMu/web-worker-test/commit/3eeefbd950692020a650d08da6ce006dfc81b986).

Steps:
1. yarn add @swtc/wallet
2. yarn add bn.js
3. npm run serve and open devtools